### PR TITLE
Remove Duplicates From Participant Table

### DIFF
--- a/participant_monitor.cpp
+++ b/participant_monitor.cpp
@@ -8,9 +8,13 @@
 #include <iostream>
 #include <chrono>
 
-
-//------------------------------------------------------------------------------
-ParticipantMonitor::ParticipantMonitor(DDS::DomainParticipant* domain, std::function<void(const ParticipantInfo&)> onAdd, std::function<void(const ParticipantInfo&)> onRemove) : m_dataReader(nullptr), m_addParticipant(onAdd), m_removeParticipant(onRemove)
+ParticipantMonitor::ParticipantMonitor(DDS::DomainParticipant* domain, ParticipantInfoCallback onAdd, ParticipantInfoCallback onRemove)
+    : m_participant_datareader(nullptr)
+    , m_participant_location_datareader(nullptr)
+    , m_participant_listener(this)
+    , m_participant_location_listener(this)
+    , m_addParticipant(onAdd)
+    , m_removeParticipant(onRemove)
 {
     DDS::Subscriber_var subscriber = domain->get_builtin_subscriber();
     if (!subscriber)
@@ -23,10 +27,10 @@ ParticipantMonitor::ParticipantMonitor(DDS::DomainParticipant* domain, std::func
     }
 
     // Find and store the built-in data reader
-    m_dataReader = subscriber->lookup_datareader(
-        OpenDDS::DCPS::BUILT_IN_PARTICIPANT_LOCATION_TOPIC);
+    m_participant_datareader = subscriber->lookup_datareader(
+        OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC);
 
-    if (!m_dataReader)
+    if (!m_participant_datareader)
     {
         std::cerr
             << "ParticipantMonitor: "
@@ -35,19 +39,126 @@ ParticipantMonitor::ParticipantMonitor(DDS::DomainParticipant* domain, std::func
         return;
     }
 
-    m_dataReader->set_listener(this, DDS::DATA_AVAILABLE_STATUS);
+    m_participant_datareader->set_listener(&m_participant_listener, DDS::DATA_AVAILABLE_STATUS);
+
+    m_participant_location_datareader = subscriber->lookup_datareader(
+        OpenDDS::DCPS::BUILT_IN_PARTICIPANT_LOCATION_TOPIC);
+
+    if (!m_participant_location_datareader)
+    {
+        std::cerr
+            << "ParticipantMonitor: "
+            << "Unable to find BUILT_IN_PARTICIPANT_LOCATION_TOPIC topic reader"
+            << std::endl;
+        return;
+    }
+
+    m_participant_location_datareader->set_listener(&m_participant_location_listener, DDS::DATA_AVAILABLE_STATUS);
 }
 
-
-//------------------------------------------------------------------------------
 ParticipantMonitor::~ParticipantMonitor()
 {   
-    m_dataReader = nullptr;  // Do not delete. We don't own it.
+    m_participant_datareader = nullptr;  // Do not delete. We don't own it.
+    m_participant_location_datareader = nullptr;  // Do not delete. We don't own it.
 }
 
+void ParticipantMonitor::on_participant_data_available(DDS::DataReader_ptr reader)
+{
+    DDS::SampleInfoSeq infoSeq;
+    DDS::ParticipantBuiltinTopicDataSeq msgList;
 
-//------------------------------------------------------------------------------
-void ParticipantMonitor::on_data_available(DDS::DataReader_ptr reader)
+    DDS::ParticipantBuiltinTopicDataDataReader_var dataReader =
+        DDS::ParticipantBuiltinTopicDataDataReader::_narrow(reader);
+
+    if (!dataReader)
+    {
+        std::cerr
+            << "ParticipantMonitor::on_data_available: "
+            << "Error calling _narrow"
+            << std::endl;
+        return;
+    }
+
+    dataReader->take(
+        msgList,
+        infoSeq,
+        DDS::LENGTH_UNLIMITED,
+        DDS::ANY_SAMPLE_STATE,
+        DDS::ANY_VIEW_STATE,
+        DDS::ANY_INSTANCE_STATE);
+
+    // Iterate through all received samples
+    CORBA::ULong msgListSize = msgList.length();
+    for (CORBA::ULong i = 0; i < msgListSize; i++)
+    {
+        const DDS::ParticipantBuiltinTopicData& sampleData = msgList[i];
+        const DDS::SampleInfo& sampleInfo = infoSeq[i];
+
+        OpenDDS::DCPS::GUID_t guid;
+        memcpy(&guid, &sampleData.key.value[0], sizeof (guid));
+
+        ParticipantInfo info;
+
+        std::unique_lock<std::mutex> lock(m_info_map_mutex);
+
+        const auto iter = m_info_map.find(guid);
+        if (iter != m_info_map.end()) {
+          info = iter->second;
+        } else {
+          // Get the GUID information into a string
+          std::ostringstream guidStream;
+          for (int j = 3; j >= 0; j--)
+          {
+              guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.key.value[j]);
+          }
+          info.hostID = guidStream.str();
+
+          guidStream.str("");
+          for (int j = 7; j >= 4; j--)
+          {
+              guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.key.value[j]);
+          }
+          info.appID = guidStream.str();
+
+          guidStream.str("");
+          for (int j = 11; j >= 8; j--)
+          {
+              guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.key.value[j]);
+          }
+          info.instanceID = guidStream.str();
+          info.guid = info.hostID + "." + info.appID + "." + info.instanceID;
+        }
+
+        if (sampleInfo.valid_data) {
+
+          const unsigned long long milliSecondsSinceEpoch = static_cast<unsigned long long>(sampleInfo.source_timestamp.sec) * 1000U + static_cast<unsigned long>(sampleInfo.source_timestamp.nanosec) / 1000000U;
+          const auto durationSinceEpoch = std::chrono::milliseconds(milliSecondsSinceEpoch);
+          const std::chrono::time_point<std::chrono::system_clock> afterDuration(durationSinceEpoch);
+          time_t timeT = std::chrono::system_clock::to_time_t(afterDuration);
+          unsigned long long remainderMS = milliSecondsSinceEpoch % 1000U;
+          std::ostringstream dateStream;
+          dateStream << std::dec << std::put_time(std::localtime(&timeT), "%F %T.") << remainderMS;
+          info.discovered_timestamp = dateStream.str();
+
+          m_info_map[guid] = info;
+        } else if (iter != m_info_map.end()) {
+          m_info_map.erase(iter);
+        }
+
+        lock.unlock();
+
+        if (sampleInfo.valid_data)
+        {
+            if (m_addParticipant) m_addParticipant(info);
+        }
+        else
+        {
+            if (m_removeParticipant) m_removeParticipant(info);
+        }
+    }
+}
+
+void ParticipantMonitor::on_participant_location_data_available(DDS::DataReader_ptr reader)
 {
     DDS::SampleInfoSeq infoSeq;
     OpenDDS::DCPS::ParticipantLocationBuiltinTopicDataSeq msgList;
@@ -78,44 +189,58 @@ void ParticipantMonitor::on_data_available(DDS::DataReader_ptr reader)
     {
         const OpenDDS::DCPS::ParticipantLocationBuiltinTopicData& sampleData = msgList[i];
         const DDS::SampleInfo& sampleInfo = infoSeq[i];
+
+        OpenDDS::DCPS::GUID_t guid;
+        memcpy(&guid, &sampleData.guid[0], sizeof (guid));
+
         ParticipantInfo info;
 
-        // Get the GUID information into a string
-        std::ostringstream guidStream;
-        for (int j = 3; j >= 0; j--)
-        {
-            guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.guid[j]);
+        std::unique_lock<std::mutex> lock(m_info_map_mutex);
+
+        const auto iter = m_info_map.find(guid);
+        if (iter != m_info_map.end()) {
+          info = iter->second;
+        } else {
+          // Get the GUID information into a string
+          std::ostringstream guidStream;
+          for (int j = 3; j >= 0; j--)
+          {
+              guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.guid[j]);
+          }
+          info.hostID = guidStream.str();
+
+          guidStream.str("");
+          for (int j = 7; j >= 4; j--)
+          {
+              guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.guid[j]);
+          }
+          info.appID = guidStream.str();
+
+          guidStream.str("");
+          for (int j = 11; j >= 8; j--)
+          {
+              guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.guid[j]);
+          }
+          info.instanceID = guidStream.str();
+          info.guid = info.hostID + "." + info.appID + "." + info.instanceID;
         }
-        info.hostID = guidStream.str();
 
-        guidStream.str("");
-        for (int j = 7; j >= 4; j--)
-        {
-            guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.guid[j]);
+        if (sampleInfo.valid_data) {
+
+          if (sampleData.location & OpenDDS::DCPS::LOCATION_LOCAL) {
+            info.location = sampleData.local_addr.in();
+          } else if (sampleData.location & OpenDDS::DCPS::LOCATION_LOCAL6) {
+            info.location = sampleData.local6_addr.in();
+          }
+
+          m_info_map[guid] = info;
+        } else if (iter != m_info_map.end()) {
+          m_info_map.erase(iter);
         }
-        info.appID = guidStream.str();
 
-        guidStream.str("");
-        for (int j = 11; j >= 8; j--)
-        {
-            guidStream << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned short>(sampleData.guid[j]);
-        }
-        info.instanceID = guidStream.str();
+        lock.unlock();
 
-        info.guid = info.hostID + "." + info.appID + "." + info.instanceID;
-        info.location = sampleData.local_addr.in();
-
-        // Convert the timestamp from DDS into a nice string
-        const unsigned long long milliSecondsSinceEpoch = static_cast<unsigned long long>(sampleData.local_timestamp.sec) * 1000U + static_cast<unsigned long>(sampleData.local_timestamp.nanosec) / 1000000U;
-        const auto durationSinceEpoch = std::chrono::milliseconds(milliSecondsSinceEpoch);
-        const std::chrono::time_point<std::chrono::system_clock> afterDuration(durationSinceEpoch);
-        time_t timeT = std::chrono::system_clock::to_time_t(afterDuration);
-        unsigned long long remainderMS = milliSecondsSinceEpoch % 1000U;
-        std::ostringstream dateStream;
-        dateStream << std::dec << std::put_time(std::localtime(&timeT), "%H:%M:%S.") << remainderMS;
-        info.timestamp = dateStream.str();
-
-        if (sampleInfo.instance_state == DDS::ALIVE_INSTANCE_STATE)
+        if (sampleInfo.valid_data)
         {
             if (m_addParticipant) m_addParticipant(info);
         }
@@ -123,14 +248,7 @@ void ParticipantMonitor::on_data_available(DDS::DataReader_ptr reader)
         {
             if (m_removeParticipant) m_removeParticipant(info);
         }
-
     }
 
     dataReader->return_loan(msgList, infoSeq);
-
 } 
-
-
-/**
- * @}
- */

--- a/participant_page.ui
+++ b/participant_page.ui
@@ -10,6 +10,11 @@
     <height>300</height>
    </rect>
   </property>
+  <property name="font">
+   <font>
+    <family>Ubuntu Mono</family>
+   </font>
+  </property>
   <property name="windowTitle">
    <string>Participants</string>
   </property>
@@ -38,7 +43,7 @@
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderDefaultSectionSize">
-      <number>19</number>
+      <number>21</number>
      </attribute>
     </widget>
    </item>

--- a/participant_table_model.cpp
+++ b/participant_table_model.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <algorithm>
 
-//------------------------------------------------------------------------------
 ParticipantTableModel::ParticipantTableModel()
     : QAbstractTableModel(nullptr)
 {
@@ -20,8 +19,6 @@ ParticipantTableModel::ParticipantTableModel()
         << "Discovered";
 }
 
-
-//------------------------------------------------------------------------------
 int ParticipantTableModel::rowCount(const QModelIndex& idx) const
 {
     if (idx.parent().isValid()) return 0;
@@ -29,19 +26,12 @@ int ParticipantTableModel::rowCount(const QModelIndex& idx) const
     return static_cast<int>(m_data.size());
 }
 
-
-//------------------------------------------------------------------------------
 int ParticipantTableModel::columnCount(const QModelIndex& /*index*/) const
 {
     return static_cast<int>(m_columnHeaders.size());
 }
 
-
-//------------------------------------------------------------------------------
-QVariant ParticipantTableModel::headerData(
-    int section,
-    Qt::Orientation orientation,
-    int role) const
+QVariant ParticipantTableModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if (role != Qt::DisplayRole)
     {
@@ -60,15 +50,11 @@ QVariant ParticipantTableModel::headerData(
     return QVariant();
 }
 
-
-//------------------------------------------------------------------------------
 Qt::ItemFlags ParticipantTableModel::flags(const QModelIndex& /*index*/) const
 {
     return Qt::ItemIsEnabled;
 }
 
-
-//------------------------------------------------------------------------------
 QVariant ParticipantTableModel::data(const QModelIndex& index, int role) const
 {
     const int column = index.column();
@@ -101,42 +87,38 @@ QVariant ParticipantTableModel::data(const QModelIndex& index, int role) const
     {
         return m_data.at(row).instanceID.c_str();
     }
-    else if (role == Qt::DisplayRole && column == COLUMN_TIMESTAMP)
+    else if (role == Qt::DisplayRole && column == COLUMN_DISCOVERED_TIMESTAMP)
     {
-        return m_data.at(row).timestamp.c_str();
+        return m_data.at(row).discovered_timestamp.c_str();
     }
 
     return QVariant();
 
-} // End ParticipantTableModel::data
+}
 
-
-//------------------------------------------------------------------------------
-void ParticipantTableModel::addParticipant(const ParticipantInfo &info)
+void ParticipantTableModel::addParticipant(const ParticipantInfo& info)
 {
     emit layoutAboutToBeChanged();
 
-    m_data.push_back(info);
-    std::sort(m_data.begin(), m_data.end()) ;
+    auto iter = std::find_if(m_data.begin(), m_data.end(), [&](const ParticipantInfo& i) { return i.guid == info.guid; });
+    if (iter != m_data.end()) {
+        *iter = info;
+    } else {
+        m_data.push_back(info);
+        std::sort(m_data.begin(), m_data.end());
+    }
 
     emit layoutChanged();
 }
 
-
-//------------------------------------------------------------------------------
-void ParticipantTableModel::removeParticipant(const ParticipantInfo &info)
+void ParticipantTableModel::removeParticipant(const ParticipantInfo& info)
 {
     emit layoutAboutToBeChanged();
 
-    auto iter = std::find(m_data.begin(), m_data.end(), info);
+    auto iter = std::find_if(m_data.begin(), m_data.end(), [&](const ParticipantInfo& i) { return i.guid == info.guid; });
     if (iter != m_data.end()) {
         m_data.erase(iter);
     }
 
     emit layoutChanged();
 }
-
-
-/**
- * @}
- */

--- a/participant_table_model.h
+++ b/participant_table_model.h
@@ -89,21 +89,19 @@ public:
         COLUMN_HOST,
         COLUMN_APP,
         COLUMN_INSTANCE,
-        COLUMN_TIMESTAMP,
+        COLUMN_DISCOVERED_TIMESTAMP,
         MAX_eColumnIds_VALUE
     };
-
-public:
 
     /**
      * @brief Add a new participant to the model.
      */
-    void addParticipant(const ParticipantInfo &);
+    void addParticipant(const ParticipantInfo& info);
 
     /**
      * @brief Remove a participant from the model.
      */
-    void removeParticipant(const ParticipantInfo &);
+    void removeParticipant(const ParticipantInfo& info);
 
 private:
 


### PR DESCRIPTION
Problem: The participant window often has duplicates of discovered participants due its use of the ParticipantLocationTopic (which can be updated as participant info changes) and no internal state tracking. Also, the participant window uses a variable-width font which makes it difficult to compare numbers and text between rows in the table.

Solution: Combine info from participant and participant location topics, prevent duplicates in the table, use a fixed-width font.