### PR TITLE
Clean Up topic_page Resource Usage

### DIFF
--- a/dds_data.cpp
+++ b/dds_data.cpp
@@ -73,37 +73,6 @@ std::shared_ptr<TopicInfo> CommonData::getTopicInfo(const QString& topicName)
     return topicInfo;
 }
 
-
-//------------------------------------------------------------------------------
-bool CommonData::createPubSub(const QString& topicName, const QString& /*filter*/)
-{
-    // Make sure we have an information object for this topic
-    std::shared_ptr<TopicInfo> topicInfo = getTopicInfo(topicName);
-    if (topicInfo == nullptr)
-    {
-        std::cerr << "Unable to find topic information for "
-                  << topicName.toStdString()
-                  << std::endl;
-
-        return false;
-    }
-
-    // Make sure the type code is valid
-    if (!topicInfo->typeCode)
-    {
-        std::cerr << "Unable to find type code information for '"
-                  << topicName.toStdString()
-                  << "'. Wait for a DDSManager publisher or subscriber..."
-                  << std::endl;
-
-        return false;
-    }
-
-    return true;
-
-} // End CommonData::createPubSub
-
-
 //------------------------------------------------------------------------------
 QVariant CommonData::readValue(const QString& topicName,
                                const QString& memberName,

--- a/dds_data.h
+++ b/dds_data.h
@@ -226,15 +226,6 @@ public:
     static std::shared_ptr<TopicInfo> getTopicInfo(const QString& topicName);
 
     /**
-     * @brief Create the publisher/subscriber objects for a given topic.
-     * @param[in] topicName The target topic name.
-     * @param[in] filter Install this topic filter if specified.
-     * @return True if the operation was successful; false otherwise.
-     */
-    static bool createPubSub(const QString& topicName,
-                             const QString& filter = "");
-
-    /**
      * @brief Read the value of a DDS sample.
      * @param[in] topicName The name of the topic.
      * @param[in] memberName The name of the topic member.

--- a/main_window.cpp
+++ b/main_window.cpp
@@ -213,13 +213,6 @@ void DDSMonitorMainWindow::on_topicTree_itemClicked(QTreeWidgetItem* item, int)
     topicInfo->subQos.partition = partitionInfo;
     topicInfo->pubQos.partition = partitionInfo;
 
-
-    if (!CommonData::createPubSub(topicName))
-    {
-        // TODO: Show a popup?
-        return;
-    }
-
     // Create a new topic page
     QIcon tableIcon(":/images/stock_data-table.png");
     TablePage* page = new TablePage(topicName, mainTabWidget);

--- a/opendds.ini
+++ b/opendds.ini
@@ -1,6 +1,6 @@
 [common]
-; Use a default RTPS configuration (local multicast) as the default discovery mechanism for all domains
-DCPSDefaultDiscovery=DEFAULT_RTPS
+; Use RTPS as the default discovery mechanism for all domains
+DCPSDefaultDiscovery=rtps_disc
 ; Use all transports defined in this file as part of the default transport configuration
 DCPSGlobalTransportConfig=$file
 ; DCPS debug level [0-10]
@@ -9,6 +9,9 @@ DCPSDebugLevel=0
 DCPSTransportDebugLevel=0
 ; Don't wait more than 3 seconds for pending (re)connections.
 DCPSPendingTimeout=3
+
+[rtps_discovery/rtps_disc]
+UseXTypes=complete
 
 ; A RTPS/UDP transport mechanism for user topics
 [transport/the_rtps_transport]

--- a/table_page.cpp
+++ b/table_page.cpp
@@ -43,7 +43,7 @@ TablePage::TablePage(const QString& topicName,
     connect(m_tableModel.get(), SIGNAL(dataHasChanged()), this, SLOT(dataHasChanged()));
 
     // Create a topic monitor to receive the data samples
-    m_topicMonitor = std::make_unique <TopicMonitor>(topicName);
+    m_topicMonitor = std::make_unique<TopicMonitor>(topicName);
     m_topicReplayer = std::make_unique<TopicReplayer>(topicName);
 
     connect(&m_refreshTimer, SIGNAL(timeout()), this, SLOT(refreshPage()));
@@ -55,8 +55,6 @@ TablePage::TablePage(const QString& topicName,
 //------------------------------------------------------------------------------
 TablePage::~TablePage()
 {
-    m_topicReplayer.release();  //Leak on purpose since DDS shutdown isn't quite right
-    m_topicMonitor.release();  //Leak on purpose since DDS shutdown isn't quite right
     CommonData::flushSamples(m_topicName);
 }
 

--- a/topic_replayer.cpp
+++ b/topic_replayer.cpp
@@ -57,15 +57,12 @@ TopicReplayer::TopicReplayer(const QString& topicName) :
         return;
     }
 
-    OpenDDS::DCPS::RcHandle<TopicReplayer> thisHandle =
-        OpenDDS::DCPS::rchandle_from(this);
-
     m_replayer = service->create_replayer(
         domain,
         m_topic,
         topicInfo->pubQos,
         topicInfo->writerQos,
-        thisHandle
+        OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::ReplayerListener>()
     );
 
     if (!m_replayer)

--- a/topic_replayer.h
+++ b/topic_replayer.h
@@ -19,7 +19,7 @@ class OpenDynamicData;
 /**
  * @brief Topic replayer for sending raw DDS data samples.
  */
-class TopicReplayer : public OpenDDS::DCPS::ReplayerListener
+class TopicReplayer
 {
 public:
 


### PR DESCRIPTION
Problem: Opening topic pages caused leak of recorder and replayer entities, meaning samples would continue to be received even after the topic window was closed (and new windows would create new entities). Trying to clean up the entities lead to SEGV issues due to improper use of Listener RcObjects (reference counting was ignored by std::unique).

Solution: Clean up RcObject usage where required and remove it where not required (replayer) and then re-enable correct topic_page cleanup to avoid resource loss.